### PR TITLE
test setup for oauth and login

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,2 +1,3 @@
 venv
 __pycache__
+config.py

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,15 +1,46 @@
 import time
+
+from authlib.integrations.flask_client import OAuth
+import flask
 from flask import Flask
+import flask_login
 from flask_graphql import GraphQLView
 from flask_sockets import Sockets
 from graphql_ws.gevent import GeventSubscriptionServer
 
-from models import db_session
+from models import db_session, User
 from schema import schema
+
+
+# flask config file, currently used for storing oauth parameters for integration with authlib
+CONFIG_FILENAME = 'config.py'
+
+# for potential redirecting to from the backend
+FRONTEND_HOST = 'scott-ubuntu.local'
+FRONTEND_PORT = 3000
+
 
 app = Flask(__name__)
 app.debug = True
+app.config.from_pyfile(CONFIG_FILENAME)
 sockets = Sockets(app)
+
+
+def get_oauth(app):
+    oauth = OAuth(app)
+    oauth.register('github')
+    return oauth
+
+
+def get_login_manager(app):
+    login_manager = flask_login.LoginManager()
+    login_manager.init_app(app)
+    return login_manager
+
+
+oauth = get_oauth(app)
+login_manager = get_login_manager(app)
+
 
 app.add_url_rule(
     '/graphql',
@@ -23,14 +54,81 @@ app.add_url_rule(
 subscription_server = GeventSubscriptionServer(schema)
 app.app_protocol = lambda environ_path_info: 'graphql-ws'
 
+
+@app.route('/login')
+def login():
+    redirect_uri = flask.url_for('authorize', _external=True)
+    return oauth.github.authorize_redirect(redirect_uri)
+
+
+@app.route('/logout')
+@flask_login.login_required
+def logout():
+    flask_login.logout_user()
+    return flask.redirect(flask.url_for('index'))
+
+
+@app.route('/authorize')
+def authorize():
+    token = oauth.github.authorize_access_token()
+    resp = oauth.github.get('user')
+    resp.raise_for_status()
+
+    profile = resp.json()
+    github_username = profile['login']
+
+    user = User.get_from_name(github_username)
+    if user is None:
+        user = User.create(github_username)
+        print(f'creating new user {user}')
+    else:
+        print(f'found existing user {user}')
+
+    flask_login.login_user(user)
+    print('current user', flask_login.current_user.name)
+
+    # NB: login/logout flow is restricted to backend for easier testing
+    # if uncommented, logging in will redirect to the actual app itself, which is tricky
+    # to add login/logout buttons to
+    # redirect_target = f'http://{FRONTEND_HOST}:{FRONTEND_PORT}'
+    # return flask.redirect(redirect_target)
+    return flask.redirect(flask.url_for('index'))
+
+
+@app.route('/')
+def index():
+    # index route just exposing login/logout buttons for testing
+    current_user = flask_login.current_user
+    if current_user.is_authenticated:
+        print('index: authenticated user', current_user.name)
+        return f'logged in as {current_user.name}<br/><a class="button" href="/logout">logout</a>'
+    else:
+        print('index: not authenticated user')
+        return f'not logged in<br/><a class="button" href="/login">login</a>'
+
+
+# required for flask_login functionality
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(user_id)
+
+
 @sockets.route('/subscriptions')
 def echo_socket(ws):
+    current_user = flask_login.current_user
+    if not current_user.is_authenticated:
+        print('websocket: not authenticated, not using websocket')
+        return
+
+    print('websocket: authenticated user', current_user.name)
     subscription_server.handle(ws)
     return []
+
 
 @app.teardown_appcontext
 def shutdown_session(exception=None):
     db_session.remove()
+
 
 if __name__ == '__main__':
     from gevent import pywsgi

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,3 +1,4 @@
+from flask_login import UserMixin
 from sqlalchemy import *
 from sqlalchemy.orm import (scoped_session, sessionmaker, relationship,
                             backref)
@@ -13,10 +14,27 @@ Base = declarative_base()
 Base.query = db_session.query_property()
 
 
-class User(Base):
+class User(Base, UserMixin):
     __tablename__ = 'user'
     id = Column(Integer, primary_key=True)
     name = Column(String)
+
+    @classmethod
+    def create(cls, name):
+        user = cls(name=name)
+        db_session.add(user)
+        db_session.commit()
+        return user
+
+    @classmethod
+    def get_from_name(cls, name):
+        return cls.query.filter(cls.name == name).first()
+
+    @classmethod
+    def delete_by_name(cls, name):
+        ret = cls.query.filter(cls.name == name).delete()
+        db_session.commit()
+        return ret
 
 
 class Todo(Base):

--- a/backend/schema.py
+++ b/backend/schema.py
@@ -21,6 +21,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+import flask_login
 import graphene
 from sqlalchemy import and_, func
 from graphene import relay
@@ -77,6 +78,11 @@ class User(SQLAlchemyObjectType):
 
 
 def get_viewer():
+    # TODO: current_user is unavailable when this is called from the frontend's connection
+    # when a user is logged in from the backend, this information is not propagated to when
+    # this endpoint is called, which thinks the user is logged out
+    # print('current user', flask_login.current_user)
+    # return flask_login.current_user
     return UserModel.query.filter(UserModel.name == 'me').first()
 
 

--- a/frontend/ts/config.ts
+++ b/frontend/ts/config.ts
@@ -1,7 +1,8 @@
 const config = {
   APP_PORT: 3000,
   BACKEND_PORT: 5000,
-  BACKEND_HOST: 'localhost',
+  // BACKEND_HOST: 'localhost',
+  BACKEND_HOST: 'scott-ubuntu.local',
   PAGE_SIZE: 3,
 }
 export default config


### PR DESCRIPTION
config.py intentionally left out as it contains keys that shouldn't be public. will share separately

steps for testing auth/login flow:

to confirm websocket connection doesn't work without login:
- open two browser tabs to the frontend app (e.g. http://scott-ubuntu.local:3000/)
- create any mutation in one of the tabs
- confirm that mutation is NOT reflected in the other tab

to test oauth login flow + confirm websocket connection works while logged in:
- login through the login button at the backend endpoint (e.g. http://scott-ubuntu.local:5000/)
- go through the oauth flow, allowing access from the Todo App github oauth app
- this should redirect to the original index endpoint, showing the logged-in github user
- open two browser tabs to the frontend app (e.g. http://scott-ubuntu.local:3000/)
- create any mutation in one of the tabs
- confirm that mutation IS reflected in the other tab

